### PR TITLE
Always fill out PR title after conflict resolution

### DIFF
--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -277,7 +277,7 @@ Co-authored-by: {get_author_info_from_short_sha(self.commit_sha1)}"""
                 click.echo(cpe.output)
         return updated_commit_message
 
-    def push_to_remote(self, base_branch, head_branch, commit_message=""):
+    def push_to_remote(self, base_branch, head_branch, commit_message):
         """ git push <origin> <branchname> """
         set_state(WORKFLOW_STATES.PUSHING_TO_REMOTE)
 
@@ -468,7 +468,10 @@ To abort the cherry-pick and cleanup:
                 ]
                 subprocess.check_output(cmd, stderr=subprocess.STDOUT)
 
-            self.push_to_remote(base, cherry_pick_branch)
+            self.push_to_remote(
+                base, cherry_pick_branch,
+                updated_commit_message,
+            )
 
             self.cleanup_branch(cherry_pick_branch)
 

--- a/cherry_picker/test.py
+++ b/cherry_picker/test.py
@@ -648,7 +648,7 @@ def test_push_to_remote_fail(tmp_git_repo_dir):
     with mock.patch("cherry_picker.cherry_picker.validate_sha", return_value=True):
         cherry_picker = CherryPicker("origin", "xxx", [])
 
-    cherry_picker.push_to_remote("master", "backport-branch-test")
+    cherry_picker.push_to_remote("master", "backport-branch-test", "")
     assert get_state() == WORKFLOW_STATES.PUSHING_TO_REMOTE_FAILED
 
 
@@ -659,7 +659,7 @@ def test_push_to_remote_interactive(tmp_git_repo_dir):
     with mock.patch.object(cherry_picker, "run_cmd"), mock.patch.object(
         cherry_picker, "open_pr"
     ), mock.patch.object(cherry_picker, "get_pr_url", return_value="https://pr_url"):
-        cherry_picker.push_to_remote("master", "backport-branch-test")
+        cherry_picker.push_to_remote("master", "backport-branch-test", "")
     assert get_state() == WORKFLOW_STATES.PR_OPENING
 
 
@@ -671,7 +671,7 @@ def test_push_to_remote_botflow(tmp_git_repo_dir, monkeypatch):
     with mock.patch.object(cherry_picker, "run_cmd"), mock.patch.object(
         cherry_picker, "create_gh_pr"
     ):
-        cherry_picker.push_to_remote("master", "backport-branch-test")
+        cherry_picker.push_to_remote("master", "backport-branch-test", "")
     assert get_state() == WORKFLOW_STATES.PR_CREATING
 
 


### PR DESCRIPTION
Before this change, cherry-picker used to loose the backported commit
message and didn't pass anything to the `push_to_remote()` method which
resulted in sending an API request to GitHub that had an empty title
upon resume. This caused GitHub respond with an error.

This code path was only problematic for people having a GitHub token in
their env and therefore enjoying the benefits of the PR autocreation.

After this change, cherry-picker picks up the commit message correctly
and extracts the proper PR title and body out of it.