### PR TITLE
Update default branch name

### DIFF
--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -25,7 +25,7 @@ DEFAULT_CONFIG = collections.ChainMap(
         "repo": "cpython",
         "check_sha": "7f777ed95a19224294949e1b4ce56bbffcb1fe9f",
         "fix_commit_msg": True,
-        "default_branch": "master",
+        "default_branch": "main",
     }
 )
 


### PR DESCRIPTION
cherry-picker died a horrible death when I tried to use it locally just now. This change fixed it.