### PR TITLE
Print new URL of cherry-picker's repository on error

### DIFF
--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -526,7 +526,7 @@ To abort the cherry-pick and cleanup:
                 "Valid states are: "
                 f'{", ".join(s.name for s in self.ALLOWED_STATES)}. '
                 "If this looks suspicious, raise an issue at "
-                "https://github.com/python/core-workflow/issues/new.\n"
+                "https://github.com/python/cherry-picker/issues/new.\n"
                 "As the last resort you can reset the runtime state "
                 "stored in Git config using the following command: "
                 "`git config --local --remove-section cherry-picker`"

--- a/cherry_picker/test.py
+++ b/cherry_picker/test.py
@@ -636,7 +636,7 @@ def test_get_state_and_verify_fail(
         r"Valid states are: "
         r"[\w_\s]+(, [\w_\s]+)*\. "
         r"If this looks suspicious, raise an issue at "
-        r"https://github.com/python/core-workflow/issues/new\."
+        r"https://github.com/python/cherry-picker/issues/new\."
         "\n"
         r"As the last resort you can reset the runtime state "
         r"stored in Git config using the following command: "


### PR DESCRIPTION
While playing with cherry_picker, I noticed that this error message still contains the old location of the cherry-picker.