### PR TITLE
Fix command for running tests in README

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -301,7 +301,7 @@ Install pytest: ``pip install -U pytest``
 
 ::
 
-    $ pytest test.py
+    $ pytest
 
 
 Publishing to PyPI


### PR DESCRIPTION
I initially wanted to change this to `pytest cherry_picker/test.py` but I noticed that this project already has a `pytest.ini` file which means that the path to the tests does not need to be passed.