### PR TITLE
Drop support for EOL Python 3.6

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,5 +1,5 @@
 name: lint_python
-on: [pull_request, push]
+on: [pull_request, push, workflow_dispatch]
 jobs:
   lint_python:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -17,5 +17,5 @@ jobs:
       - run: isort --check-only --profile black .
       - run: pip install --editable .
       - run: mypy --ignore-missing-imports --install-types --non-interactive .
-      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
+      - run: shopt -s globstar && pyupgrade --py37-plus **/*.py || true
       - run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -4,8 +4,11 @@ jobs:
   lint_python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          cache: pip
+          cache-dependency-path: .github/workflows/lint_python.yml
       - run: pip install --upgrade pip wheel
       - run: pip install bandit black codespell flake8 flake8-bugbear
                          flake8-comprehensions isort mypy pyupgrade safety

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: tests
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,15 +17,17 @@ jobs:
         - windows-latest
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # fetch all branches and tags
           # ref actions/checkout#448
           fetch-depth: 0
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
+          cache: pip
+          cache-dependency-path: .github/workflows/main.yml
       - name: Install package
         run: |
           python -m pip install .[dev]
@@ -38,11 +40,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: "3.10"
+          cache: pip
+          cache-dependency-path: .github/workflows/main.yml
       - name: Install tools
         run: |
           python -m pip install build twine

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,8 @@ jobs:
     strategy:
       matrix:
         python:
-        - 3.6
+        - 3.7
+        - 3.8
         - 3.9
         - "3.10"
         platform:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ maintainer-email = "core-workflow@python.org"
 home-page = "https://github.com/python/cherry_picker"
 requires = ["click>=6.0", "gidgethub", "requests", "toml"]
 description-file = "readme.rst"
-classifiers = ["Programming Language :: Python :: 3.6", "Intended Audience :: Developers", "License :: OSI Approved :: Apache Software License"]
-requires-python = ">=3.6"
+classifiers = ["Programming Language :: Python :: 3.7", "Intended Audience :: Developers", "License :: OSI Approved :: Apache Software License"]
+requires-python = ">=3.7"
 
 
 [tool.flit.scripts]

--- a/readme.rst
+++ b/readme.rst
@@ -32,7 +32,7 @@ Setup Info
 
 Requires Python 3.7.
 
-::
+.. code-block:: console
 
     $ python3 -m venv venv
     $ source venv/bin/activate
@@ -42,14 +42,18 @@ The cherry picking script assumes that if an ``upstream`` remote is defined, the
 it should be used as the source of upstream changes and as the base for
 cherry-pick branches. Otherwise, ``origin`` is used for that purpose.
 
-Verify that an ``upstream`` remote is set to the CPython repository::
+Verify that an ``upstream`` remote is set to the CPython repository:
+
+.. code-block:: console
 
     $ git remote -v
     ...
     upstream	https://github.com/python/cpython (fetch)
     upstream	https://github.com/python/cpython (push)
 
-If needed, create the ``upstream`` remote::
+If needed, create the ``upstream`` remote:
+
+.. code-block:: console
 
     $ git remote add upstream https://github.com/python/cpython.git
 
@@ -67,7 +71,7 @@ Cherry-picking 🐍🍒⛏️
 
 From the cloned CPython directory:
 
-::
+.. code-block:: console
 
     (venv) $ cherry_picker [--pr-remote REMOTE] [--dry-run] [--config-path CONFIG-PATH] [--abort/--continue] [--status] [--push/--no-push] <commit_sha1> <branches>
 
@@ -104,7 +108,9 @@ Additional options::
                    (`.cherry_picker.toml` from project root by default)
 
 
-Configuration file example::
+Configuration file example:
+
+.. code-block:: toml
 
    team = "aio-libs"
    repo = "aiohttp"
@@ -176,14 +182,14 @@ For example, to cherry-pick ``6de2b7817f-some-commit-sha1-d064`` into
 ``3.5`` and ``3.6``, run the following command from the cloned CPython
 directory:
 
-::
+.. code-block:: console
 
     (venv) $ cherry_picker 6de2b7817f-some-commit-sha1-d064 3.5 3.6
 
 
 What this will do:
 
-::
+.. code-block:: console
 
     (venv) $ git fetch upstream
 
@@ -215,7 +221,9 @@ In case of merge conflicts or errors, the following message will be displayed::
 
 
 Passing the ``--dry-run`` option will cause the script to print out all the
-steps it would execute without actually executing any of them. For example::
+steps it would execute without actually executing any of them. For example:
+
+.. code-block:: console
 
     $ cherry_picker --dry-run --pr-remote pr 1e32a1be4a1705e34011770026cb64ada2d340b5 3.6 3.5
     Dry run requested, listing expected command sequence
@@ -265,7 +273,9 @@ Continues the current cherry-pick, commits, pushes the current branch to
 Changes won't be pushed to remote.  This allows you to test and make additional
 changes.  Once you're satisfied with local changes, use ``--continue`` to complete
 the backport, or ``--abort`` to cancel and clean up the branch.  You can also
-cherry-pick additional commits, by::
+cherry-pick additional commits, by:
+
+.. code-block:: console
 
    $ git cherry-pick -x <commit_sha1>
 
@@ -299,7 +309,7 @@ Running Tests
 
 Install pytest: ``pip install -U pytest``
 
-::
+.. code-block:: console
 
     $ pytest
 
@@ -318,9 +328,11 @@ Local installation
 ==================
 
 With `flit <https://flit.readthedocs.io/en/latest/>`_ installed,
-in the directory where ``pyproject.toml`` exists::
+in the directory where ``pyproject.toml`` exists:
 
-    flit install
+.. code-block:: console
+
+    $ flit install
 
 
 .. |pyversion status| image:: https://img.shields.io/pypi/pyversions/cherry-picker.svg

--- a/readme.rst
+++ b/readme.rst
@@ -30,7 +30,7 @@ Tests are to be written using `pytest <https://docs.pytest.org/en/latest/>`_.
 Setup Info
 ==========
 
-Requires Python 3.6.
+Requires Python 3.7.
 
 ::
 

--- a/readme.rst
+++ b/readme.rst
@@ -4,7 +4,7 @@ Usage (from a cloned CPython directory) ::
 
 |pyversion status|
 |pypi status|
-|travis status|
+|github actions status|
 
 .. contents::
 
@@ -341,8 +341,8 @@ in the directory where ``pyproject.toml`` exists:
 .. |pypi status| image:: https://img.shields.io/pypi/v/cherry-picker.svg
    :target: https://pypi.org/project/cherry-picker/
 
-.. |travis status| image:: https://travis-ci.com/python/cherry-picker.svg?branch=main
-   :target: https://travis-ci.com/python/cherry-picker
+.. |github actions status| image:: https://github.com/python/cherry-picker/actions/workflows/main.yml/badge.svg
+   :target: https://github.com/python/cherry-picker/actions/workflows/main.yml
 
 Changelog
 =========


### PR DESCRIPTION
Also:

* README: Update RST formatting
* README: Replace Travis CI badge with GitHub Actions
* Github Actions: Add `workflow_dispatch` to add a button to manually trigger builds, like in Travis CI
* Github Actions: Bump actions to v3 and cache pip
