### PR TITLE
Add support for git clones made with the `--mirror` option

### DIFF
--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -438,7 +438,8 @@ Co-authored-by: {get_author_info_from_short_sha(self.commit_sha1)}"""
                     self.push_to_remote(
                         maint_branch, cherry_pick_branch, commit_message
                     )
-                    self.cleanup_branch(cherry_pick_branch)
+                    if not self.is_mirror():
+                        self.cleanup_branch(cherry_pick_branch)
                 else:
                     click.echo(
                         f"""
@@ -517,7 +518,8 @@ To abort the cherry-pick and cleanup:
 
             self.push_to_remote(base, cherry_pick_branch)
 
-            self.cleanup_branch(cherry_pick_branch)
+            if not self.is_mirror():
+                self.cleanup_branch(cherry_pick_branch)
 
             click.echo("\nBackport PR:\n")
             click.echo(updated_commit_message)

--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -323,7 +323,7 @@ Co-authored-by: {get_author_info_from_short_sha(self.commit_sha1)}"""
             cmd.append("--force-with-lease")
         cmd.append(self.pr_remote)
         if not self.is_mirror():
-            cmd += [f"{head_branch}:{head_branch}"]
+            cmd.append(f"{head_branch}:{head_branch}")
         try:
             self.run_cmd(cmd)
             set_state(WORKFLOW_STATES.PUSHED_TO_REMOTE)


### PR DESCRIPTION
In case of a git repository mirror, all branches are kept in sync all the time.
Trying to push out a particular refspec errors out with:

```
Failed to push to origin ☹
fatal: --mirror can't be combined with refspecs
```

Moreover, when a cherry-pick is pushed and the branch gets auto-deleted by `cherry-picker`, this introduces a dangerous situation for `--mirror` users. Again, with `--mirror` all branches are kept in sync. If I delete a branch locally from my `ambv/cpython` repository and then I push this change to GitHub, the remote branch will get automatically deleted on GitHub as well. So, if `cherry-picker` deletes a branch for PR-1, and then I push another unrelated change before PR-1 gets merged, PR-1 will get automatically closed by GitHub because the branch got deleted.

This change adds support for mirrors. Tested with:

https://github.com/python/cpython/pull/92981
https://github.com/python/cpython/pull/94495
https://github.com/python/cpython/pull/94496 (pushing this one didn't auto-close the previous one)