### PR TITLE
Clarify that ``git`` ``2.28.0+`` is needed for tests

### DIFF
--- a/cherry_picker/test_cherry_picker.py
+++ b/cherry_picker/test_cherry_picker.py
@@ -115,8 +115,9 @@ def tmp_git_repo_dir(tmpdir, cd, git_init, git_commit, git_config):
         git_init()
     except subprocess.CalledProcessError:
         version = subprocess.run(("git", "--version"), capture_output=True)
-        split_version = version.stdout.decode("utf--8").split(".")
-        if int(split_version[0][-1]) < 1 or int(split_version[1]) < 28:
+        # the output looks like "git version 2.34.1"
+        v = version.stdout.decode("utf-8").removeprefix('git version ').split('.')
+        if (int(v[0]), int(v[1]) < (2, 28):
             warnings.warn(
                 "You need git 2.28.0 or newer to run the full test suite.",
                 UserWarning,

--- a/cherry_picker/test_cherry_picker.py
+++ b/cherry_picker/test_cherry_picker.py
@@ -117,7 +117,7 @@ def tmp_git_repo_dir(tmpdir, cd, git_init, git_commit, git_config):
         version = subprocess.run(("git", "--version"), capture_output=True)
         # the output looks like "git version 2.34.1"
         v = version.stdout.decode("utf-8").removeprefix('git version ').split('.')
-        if (int(v[0]), int(v[1]) < (2, 28):
+        if (int(v[0]), int(v[1])) < (2, 28):
             warnings.warn(
                 "You need git 2.28.0 or newer to run the full test suite.",
                 UserWarning,

--- a/cherry_picker/test_cherry_picker.py
+++ b/cherry_picker/test_cherry_picker.py
@@ -1,9 +1,9 @@
 import os
 import pathlib
 import subprocess
+import warnings
 from collections import ChainMap
 from unittest import mock
-import warnings
 
 import click
 import pytest

--- a/cherry_picker/test_cherry_picker.py
+++ b/cherry_picker/test_cherry_picker.py
@@ -114,7 +114,7 @@ def tmp_git_repo_dir(tmpdir, cd, git_init, git_commit, git_config):
     try:
         git_init()
     except subprocess.CalledProcessError:
-        version = subprocess.run(["git", "--version"], capture_output=True)
+        version = subprocess.run(("git", "--version"), capture_output=True)
         split_version = version.stdout.decode("utf--8").split(".")
         if int(split_version[0][-1]) < 1 or int(split_version[1]) < 28:
             warnings.warn(

--- a/readme.rst
+++ b/readme.rst
@@ -323,6 +323,7 @@ Install pytest: ``pip install -U pytest``
 
     $ pytest
 
+Tests require your local version of ``git`` to be ``2.28.0+``.
 
 Publishing to PyPI
 ==================


### PR DESCRIPTION
``git init --initial-branch`` was only added in `2.28`. It's being used in one of the fixtures so this should probably be documented.

See: https://git-scm.com/docs/git-init/2.28.0