### PR TITLE
Use ``tomli`` and ``tomllib`` instead of ``toml``

### DIFF
--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -10,10 +10,14 @@ import webbrowser
 
 import click
 import requests
-import toml
 from gidgethub import sansio
 
 from . import __version__
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 CREATE_PR_URL_TEMPLATE = (
     "https://api.github.com/repos/{config[team]}/{config[repo]}/pulls"
@@ -837,7 +841,7 @@ def load_config(path=None):
 
     if path is not None:
         config_text = from_git_rev_read(path)
-        d = toml.loads(config_text)
+        d = tomllib.loads(config_text)
         config = config.new_child(d)
 
     return path, config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ author-email = "mariatta@python.org"
 maintainer = "Python Core Developers"
 maintainer-email = "core-workflow@python.org"
 home-page = "https://github.com/python/cherry_picker"
-requires = ["click>=6.0", "gidgethub", "requests", "toml"]
+requires = ["click>=6.0", "gidgethub", "requests", "tomli>=1.1.0;python_version<'3.11'"]
 description-file = "readme.rst"
 classifiers = ["Programming Language :: Python :: 3.7", "Intended Audience :: Developers", "License :: OSI Approved :: Apache Software License"]
 requires-python = ">=3.7"


### PR DESCRIPTION
Closes #59.

Did this in a similar way as many other packages or doing this. If the `sys` guard is not desired I'll obviously remove it.