### PR TITLE
Test with tox and upload coverage to Codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,15 @@
+# .coveragerc to control coverage.py
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma:
+    pragma: no cover
+
+    # Don't complain if non-runnable code isn't run:
+    if __name__ == .__main__.:
+    def cherry_pick_cli
+
+[run]
+omit =
+    cherry_picker/__main__.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: tests
 
 on: [push, pull_request, workflow_dispatch]
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   test:
     strategy:
@@ -22,17 +25,22 @@ jobs:
           # fetch all branches and tags
           # ref actions/checkout#448
           fetch-depth: 0
-      - name: Setup Python
-        uses: actions/setup-python@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           cache: pip
-          cache-dependency-path: .github/workflows/main.yml
-      - name: Install package
+          cache-dependency-path: pyproject.toml
+      - name: Install tox
         run: |
-          python -m pip install .[dev]
+          python -m pip install tox
       - name: Run tests
-        run: pytest
+        run: tox -e py
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          flags: ${{ matrix.os }}
+          name: ${{ matrix.os }} Python ${{ matrix.python-version }}
 
   release:
     needs: test
@@ -42,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
           cache: pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,4 @@ requires-python = ">=3.7"
 cherry_picker = "cherry_picker.cherry_picker:cherry_pick_cli"
 
 [tool.flit.metadata.requires-extra]
-dev = ["pytest"]
+dev = ["pytest", "pytest-cov"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist =
+    py{310, 39, 38, 37}
+isolated_build = true
+
+[testenv]
+passenv =
+    FORCE_COLOR
+extras =
+    dev
+commands =
+    {envpython} -m pytest --cov cherry_picker --cov-report html --cov-report term --cov-report xml {posargs}


### PR DESCRIPTION
tox allows easily testing multiple versions locally and takes care of handling virtual environments.

Let's also use tox on the CI (which tests the tox config), and measure and send coverage to Codecov.