### PR TITLE
Test Python 3.11 beta

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,12 +8,14 @@ env:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         python:
         - 3.7
         - 3.8
         - 3.9
         - "3.10"
+        - "3.11-dev"
         platform:
         - ubuntu-latest
         - macos-latest

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,5 +3,9 @@ norecursedirs = dist docs build .git .eggs .tox
 addopts = --durations=10 -v -rxXs --doctest-modules
 filterwarnings =
     error
+    # 3.11: Pending release of https://github.com/certifi/python-certifi/pull/199
+    ignore:path is deprecated. Use files\(\) instead.*:DeprecationWarning
+    # 3.11: Pending release of https://github.com/brettcannon/gidgethub/pull/185
+    ignore:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning
 junit_duration_report = call
 junit_suite_name = cherry_picker_test_suite

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{310, 39, 38, 37}
+    py{311, 310, 39, 38, 37}
 isolated_build = true
 
 [testenv]


### PR DESCRIPTION
The [doctest failure](https://github.com/hugovk/cherry-picker/runs/7266566357?check_suite_focus=true) I mentioned in https://github.com/python/cherry-picker/pull/68#discussion_r917312243 is no longer happening, possibly because 3.11 beta 4 is now out :)

Also ignore deprecation warnings in two dependencies, so they don't cause errors here. They have fixes pending release:

* https://github.com/certifi/python-certifi/pull/199
* https://github.com/brettcannon/gidgethub/pull/185