### PR TITLE
Remove filtered warning after fixed dependency released

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,5 @@ norecursedirs = dist docs build .git .eggs .tox
 addopts = --durations=10 -v -rxXs --doctest-modules
 filterwarnings =
     error
-    # 3.11: Pending release of https://github.com/brettcannon/gidgethub/pull/185
-    ignore:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning
 junit_duration_report = call
 junit_suite_name = cherry_picker_test_suite

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,8 +3,6 @@ norecursedirs = dist docs build .git .eggs .tox
 addopts = --durations=10 -v -rxXs --doctest-modules
 filterwarnings =
     error
-    # 3.11: Pending release of https://github.com/certifi/python-certifi/pull/199
-    ignore:path is deprecated. Use files\(\) instead.*:DeprecationWarning
     # 3.11: Pending release of https://github.com/brettcannon/gidgethub/pull/185
     ignore:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning
 junit_duration_report = call


### PR DESCRIPTION
The certifi library has just been released with its deprecation warning fixed, we can remove this workaround:

* https://github.com/certifi/python-certifi/pull/199#issuecomment-1241602032

We need to keep the gidgethub workaround, it's fixed but not yet released:

* https://github.com/brettcannon/gidgethub/pull/185