### PR TITLE
Fix --dry-run option incorrect behaviour

### DIFF
--- a/cherry_picker/test_cherry_picker.py
+++ b/cherry_picker/test_cherry_picker.py
@@ -581,7 +581,7 @@ def test_start_end_states(method_name, start_state, end_state, tmp_git_repo_dir)
     cherry_picker.remember_previous_branch()
     assert get_state() == WORKFLOW_STATES.UNSET
 
-    def _fetch(cmd):
+    def _fetch(cmd, *args, **kwargs):
         assert get_state() == start_state
 
     with mock.patch.object(cherry_picker, "run_cmd", _fetch):


### PR DESCRIPTION
```
# No setting upstream, so output command sequence should print origin
root@2ec8214d91c9:/tmp/cpython# git remote get-url upstream
error: No such remote 'upstream'
```

```
root@2ec8214d91c9:/tmp/cpython# cherry_picker --dry-run ab5b56ba6d 3.7
... ...
Dry run requested, listing expected command sequence
  dry-run: git remote get-url upstream
  dry-run: git fetch upstream --no-tags
Now backporting 'ab5b56ba6d' into '3.7'
  dry-run: git remote get-url upstream
  dry-run: git checkout -b backport-ab5b56b-3.7 upstream/3.7
  dry-run: git cherry-pick -x ab5b56ba6d

  dry-run: git show -s --format=%B ab5b56ba6d
Traceback (most recent call last):
... ...

  File "/usr/local/lib/python3.10/dist-packages/cherry_picker/cherry_picker.py", line 645, in cherry_pick_cli
    cherry_picker.backport()
  File "/usr/local/lib/python3.10/dist-packages/cherry_picker/cherry_picker.py", line 387, in backport
    commit_message = self.amend_commit_message(cherry_pick_branch)
  File "/usr/local/lib/python3.10/dist-packages/cherry_picker/cherry_picker.py", line 269, in amend_commit_message
    updated_commit_message = f"""{commit_prefix}{self.get_commit_message(self.commit_sha1)}
  File "/usr/local/lib/python3.10/dist-packages/cherry_picker/cherry_picker.py", line 211, in get_commit_message
    message = self.run_cmd(cmd).strip()
AttributeError: 'NoneType' object has no attribute 'strip'
```

Signed-off-by: Chenyang Yan <memory.yancy@gmail.com>