### PR TITLE
Update project configuration to use PEP 621

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,22 +1,34 @@
 [build-system]
-requires = ["flit"]
-build-backend = "flit.buildapi"
+requires = ["flit_core>=3.2,<4"]
+build-backend = "flit_core.buildapi"
 
-[tool.flit.metadata]
-module = "cherry_picker"
-author = "Mariatta Wijaya"
-author-email = "mariatta@python.org"
-maintainer = "Python Core Developers"
-maintainer-email = "core-workflow@python.org"
-home-page = "https://github.com/python/cherry_picker"
-requires = ["click>=6.0", "gidgethub", "requests", "tomli>=1.1.0;python_version<'3.11'"]
-description-file = "readme.rst"
-classifiers = ["Programming Language :: Python :: 3.7", "Intended Audience :: Developers", "License :: OSI Approved :: Apache Software License"]
+[project]
+name = "cherry_picker"
+authors = [{ name = "Mariatta Wijaya", email = "mariatta@python.org" }]
+maintainers = [{ name = "Python Core Developers", email = "core-workflow@python.org" }]
+dependencies = [
+    "click>=6.0",
+    "gidgethub",
+    "requests",
+    "tomli>=1.1.0;python_version<'3.11'",
+]
+readme = "readme.rst"
+classifiers = [
+    "Programming Language :: Python :: 3.7",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+]
 requires-python = ">=3.7"
+dynamic = ["version", "description"]
 
+[project.urls]
+"Homepage" = "https://github.com/python/cherry_picker"
 
-[tool.flit.scripts]
+[project.scripts]
 cherry_picker = "cherry_picker.cherry_picker:cherry_pick_cli"
 
-[tool.flit.metadata.requires-extra]
-dev = ["pytest", "pytest-cov"]
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-cov",
+]


### PR DESCRIPTION
The flit project configuration was using a bit outdated format so I figured it would make sense to update it to use PEP 621 (the selfish reason for this is that I wanted to quickly check something about cherry_picker's metadata and usage of flit-specific format threw me off a bit since I've grown accustomed to PEP 621 format in projects that use flit :smile:). Also, switched the build system to `flit_core` rather than `flit` as recommended by flit's documentation.