### PR TITLE
Fixes to lint CI

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -11,7 +11,7 @@ jobs:
           cache-dependency-path: .github/workflows/lint_python.yml
       - run: pip install --upgrade pip wheel
       - run: pip install --upgrade bandit black codespell flake8 flake8-bugbear
-                         flake8-comprehensions isort mypy pyupgrade safety
+                         flake8-comprehensions isort mypy pyupgrade safety setuptools
       - run: bandit --recursive --skip B101,B404,B603 .
       - run: black --diff .
       - run: codespell --ignore-words-list="commitish"

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -10,7 +10,7 @@ jobs:
           cache: pip
           cache-dependency-path: .github/workflows/lint_python.yml
       - run: pip install --upgrade pip wheel
-      - run: pip install bandit black codespell flake8 flake8-bugbear
+      - run: pip install --upgrade bandit black codespell flake8 flake8-bugbear
                          flake8-comprehensions isort mypy pyupgrade safety
       - run: bandit --recursive --skip B101,B404,B603 .
       - run: black --diff .

--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -440,7 +440,7 @@ $ cherry_picker --abort
             "maintainer_can_modify": True,
         }
         url = CREATE_PR_URL_TEMPLATE.format(config=self.config)
-        response = requests.post(url, headers=request_headers, json=data)
+        response = requests.post(url, headers=request_headers, json=data, timeout=10)
         if response.status_code == requests.codes.created:
             response_data = response.json()
             click.echo(f"Backport PR created at {response_data['html_url']}")

--- a/cherry_picker/test_cherry_picker.py
+++ b/cherry_picker/test_cherry_picker.py
@@ -135,6 +135,7 @@ def tmp_git_repo_dir(tmpdir, cd, git_init, git_commit, git_config):
             warnings.warn(
                 "You need git 2.28.0 or newer to run the full test suite.",
                 UserWarning,
+                stacklevel=2,
             )
     git_config("--local", "user.name", "Monty Python")
     git_config("--local", "user.email", "bot@python.org")


### PR DESCRIPTION
- Add a timeout of 10 seconds (is it enough?) to solve [B113:request_without_timeout](https://bandit.readthedocs.io/en/1.7.5/plugins/b113_request_without_timeout.html as of bandit 1.7.5
- Set stacklevel=2 in warning to handle flake8's B028
- Add `--upgrade` to pip install because old versions were being used (e.g. safety 2.3.4 when there is 2.3.5, or setuptools 18.9 when there are newer)
- Add setuptools package because safety complains about setuptools<65.5.1 but requires >18.9 (upstream fixed for yet unreleased 2.4.0, see https://github.com/pyupio/safety/commit/509f977ced56386becbd737a51846ec536166315). This could be undone when 2.4.0 lands

Fixes #80 