### PR TITLE
Update homepage link

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ requires-python = ">=3.7"
 dynamic = ["version", "description"]
 
 [project.urls]
-"Homepage" = "https://github.com/python/cherry_picker"
+"Homepage" = "https://github.com/python/cherry-picker"
 
 [project.scripts]
 cherry_picker = "cherry_picker.cherry_picker:cherry_pick_cli"


### PR DESCRIPTION
This repo is `https://github.com/python/cherry-picker` not `https://github.com/python/cherry_picker` (although the other one redirects here).