### PR TITLE
Test Python 3.12 pre-releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,21 +7,12 @@ env:
 
 jobs:
   test:
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python:
-        - 3.7
-        - 3.8
-        - 3.9
-        - "3.10"
-        - "3.11"
-        - "3.12-dev"
-        platform:
-        - ubuntu-latest
-        - macos-latest
-        - windows-latest
-    runs-on: ${{ matrix.platform }}
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -31,7 +22,8 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
           cache: pip
           cache-dependency-path: pyproject.toml
       - name: Install tox
@@ -55,7 +47,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.x"
           cache: pip
           cache-dependency-path: .github/workflows/main.yml
       - name: Install tools


### PR DESCRIPTION
Add `"3.12"` to the matrix along with set `allow-prereleases: true` so we don't have to use `"3.12-dev"` and change it later.

Plus refactor the other config to make it closer to our other repos, and use `"3.x"` for deploying; this will be a recent stable, which is 3.11 now.