### PR TITLE
Unset backport branch's remote from upstream

### DIFF
--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -244,6 +244,9 @@ class CherryPicker:
             )
             click.echo(err.output)
             raise BranchCheckoutException(checked_out_branch)
+        if create_branch:
+            self.unset_upstream(checked_out_branch)
+
 
     def get_commit_message(self, commit_sha):
         """
@@ -484,6 +487,13 @@ $ cherry_picker --abort
         else:
             click.echo(f"branch {branch} has been deleted.")
             set_state(WORKFLOW_STATES.REMOVED_BACKPORT_BRANCH)
+
+    def unset_upstream(self, branch):
+        cmd = ["git", "branch", "--unset-upstream", branch]
+        try:
+            return self.run_cmd(cmd)
+        except subprocess.CalledProcessError as cpe:
+            click.echo(cpe.output)
 
     def backport(self):
         if not self.branches:

--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -109,7 +109,6 @@ class CherryPicker:
         chosen_config_path=None,
         auto_pr=True,
     ):
-
         self.chosen_config_path = chosen_config_path
         """The config reference used in the current runtime.
 
@@ -239,14 +238,11 @@ class CherryPicker:
         try:
             self.run_cmd(cmd)
         except subprocess.CalledProcessError as err:
-            click.echo(
-                f"Error checking out the branch {checked_out_branch!r}."
-            )
+            click.echo(f"Error checking out the branch {checked_out_branch!r}.")
             click.echo(err.output)
             raise BranchCheckoutException(checked_out_branch)
         if create_branch:
             self.unset_upstream(checked_out_branch)
-
 
     def get_commit_message(self, commit_sha):
         """


### PR DESCRIPTION
This way the user can easily commit and push further changes to the backport, if needed, without having to remember to append their fork's remote name to `git push`.

The branch sets the upstream as the remote during `git checkout -b`. This isn't a useful default as we push the resulting backport to the user's fork anyway and it is never intended to either merge further upstream changes nor to push to upstream directly.