### PR TITLE
Remove `initial_state` as it gets out of sync with what's in .git/config

### DIFF
--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -119,7 +119,6 @@ class CherryPicker:
         self.config = config
         self.check_repo()  # may raise InvalidRepoException
 
-        self.initial_state = self.get_state_and_verify()
         """The runtime state loaded from the config.
 
         Used to verify that we resume the process from the valid
@@ -540,9 +539,10 @@ $ cherry_picker --abort
         """
         run `git cherry-pick --abort` and then clean up the branch
         """
-        if self.initial_state != WORKFLOW_STATES.BACKPORT_PAUSED:
+        state = self.get_state_and_verify()
+        if state != WORKFLOW_STATES.BACKPORT_PAUSED:
             raise ValueError(
-                f"One can only abort a paused process. Current state: {self.initial_state}. Expected state: {WORKFLOW_STATES.BACKPORT_PAUSED}"
+                f"One can only abort a paused process. Current state: {state}. Expected state: {WORKFLOW_STATES.BACKPORT_PAUSED}"
             )
 
         try:
@@ -572,8 +572,11 @@ $ cherry_picker --abort
         open the PR
         clean up branch
         """
-        if self.initial_state != WORKFLOW_STATES.BACKPORT_PAUSED:
-            raise ValueError("One can only continue a paused process.")
+        state = self.get_state_and_verify()
+        if state != WORKFLOW_STATES.BACKPORT_PAUSED:
+            raise ValueError(
+                f"One can only continue a paused process. Current state: {state}. Expected state: {WORKFLOW_STATES.BACKPORT_PAUSED}"
+            )
 
         cherry_pick_branch = get_current_branch()
         if cherry_pick_branch.startswith("backport-"):


### PR DESCRIPTION
Currently, `miss-islington` use of `cherry-picker` is aborting the cherry pick in case of conflicts. This doesn't work because `self.initial_state` is not being updated after conflicts are discovered by `cherry-picker`, and so the abort is raising a ValueError from the guard at the start of `abort_cherry_pick()`.

Since `self.initial_state` is only used for those guards, let's just remove it and read from `.git/config` every time.