### PR TITLE
Build via 'python -m build'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
           python -m pip install build twine
       - name: Release
         run: |
-          build .
+          python -m build .
           twine upload dist/*
         env:
           TWINE_USERNAME: __token__


### PR DESCRIPTION
This should fix https://github.com/python/cherry-picker/issues/91.

```console
❯ python -m build .
* Creating virtualenv isolated environment...
* Installing packages in isolated environment... (flit_core>=3.2,<4)
* Getting build dependencies for sdist...
* Building sdist...
* Building wheel from sdist
* Creating virtualenv isolated environment...
* Installing packages in isolated environment... (flit_core>=3.2,<4)
* Getting build dependencies for wheel...
* Building wheel...
Successfully built cherry_picker-2.2.0.tar.gz and cherry_picker-2.2.0-py3-none-any.whl

❯ ls dist
cherry_picker-2.2.0-py3-none-any.whl cherry_picker-2.2.0.tar.gz
```

