### PR TITLE
Publish to PyPI using Trusted Publishers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Build & maybe upload PyPI package
+name: Build package
 
 on:
   push:
@@ -22,7 +22,7 @@ jobs:
 
       - uses: hynek/build-and-inspect-python-package@v1
 
-  # Upload to Test PyPI on every commit on main.
+  # Publish to Test PyPI on every commit on main.
   release-test-pypi:
     name: Publish in-dev package to test.pypi.org
     if: |
@@ -42,14 +42,14 @@ jobs:
           name: Packages
           path: dist
 
-      - name: Upload package to Test PyPI
+      - name: Publish to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
 
-  # Upload to real PyPI on GitHub Releases.
+  # Publish to PyPI on GitHub Releases.
   release-pypi:
-    name: Publish released package to pypi.org
+    name: Publish to PyPI
     # Only run for published releases.
     if: |
       github.repository_owner == 'python'
@@ -67,5 +67,5 @@ jobs:
           name: Packages
           path: dist
 
-      - name: Upload package to PyPI
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,71 @@
+name: Build & maybe upload PyPI package
+
+on:
+  push:
+  pull_request:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # Always build & lint package.
+  build-package:
+    name: Build & verify package
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hynek/build-and-inspect-python-package@v1
+
+  # Upload to Test PyPI on every commit on main.
+  release-test-pypi:
+    name: Publish in-dev package to test.pypi.org
+    if: |
+      github.repository_owner == 'python'
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: build-package
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download packages built by build-and-inspect-python-package
+        uses: actions/download-artifact@v3
+        with:
+          name: Packages
+          path: dist
+
+      - name: Upload package to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  # Upload to real PyPI on GitHub Releases.
+  release-pypi:
+    name: Publish released package to pypi.org
+    # Only run for published releases.
+    if: |
+      github.repository_owner == 'python'
+      && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    needs: build-package
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download packages built by build-and-inspect-python-package
+        uses: actions/download-artifact@v3
+        with:
+          name: Packages
+          path: dist
+
+      - name: Upload package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/cherry_picker/__init__.py
+++ b/cherry_picker/__init__.py
@@ -1,2 +1,4 @@
 """Backport CPython changes from main to maintenance branches."""
-__version__ = "2.2.0"
+import importlib.metadata
+
+__version__ = importlib.metadata.version(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [build-system]
-build-backend = "flit_core.buildapi"
+build-backend = "hatchling.build"
 requires = [
-  "flit_core<4,>=3.2",
+  "hatch-vcs",
+  "hatchling",
 ]
 
 [project]
@@ -39,3 +40,9 @@ dev = [
 "Homepage" = "https://github.com/python/cherry-picker"
 [project.scripts]
 cherry_picker = "cherry_picker.cherry_picker:cherry_pick_cli"
+
+[tool.hatch]
+version.source = "vcs"
+
+[tool.hatch.version.raw-options]
+local_scheme = "no-local-version"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,34 +1,41 @@
 [build-system]
-requires = ["flit_core>=3.2,<4"]
 build-backend = "flit_core.buildapi"
+requires = [
+  "flit_core<4,>=3.2",
+]
 
 [project]
-name = "cherry_picker"
-authors = [{ name = "Mariatta Wijaya", email = "mariatta@python.org" }]
-maintainers = [{ name = "Python Core Developers", email = "core-workflow@python.org" }]
-dependencies = [
-    "click>=6.0",
-    "gidgethub",
-    "requests",
-    "tomli>=1.1.0;python_version<'3.11'",
-]
+name = "cherry-picker"
 readme = "readme.rst"
-classifiers = [
-    "Programming Language :: Python :: 3.8",
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
-]
+maintainers = [{ name = "Python Core Developers", email = "core-workflow@python.org" }]
+authors = [{ name = "Mariatta Wijaya", email = "mariatta@python.org" }]
 requires-python = ">=3.8"
-dynamic = ["version", "description"]
-
-[project.urls]
-"Homepage" = "https://github.com/python/cherry-picker"
-
-[project.scripts]
-cherry_picker = "cherry_picker.cherry_picker:cherry_pick_cli"
-
+classifiers = [
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+]
+dynamic = [
+  "description",
+  "version",
+]
+dependencies = [
+  "click>=6",
+  "gidgethub",
+  "requests",
+  'tomli>=1.1; python_version < "3.11"',
+]
 [project.optional-dependencies]
 dev = [
-    "pytest",
-    "pytest-cov",
+  "pytest",
+  "pytest-cov",
 ]
+[project.urls]
+"Homepage" = "https://github.com/python/cherry-picker"
+[project.scripts]
+cherry_picker = "cherry_picker.cherry_picker:cherry_pick_cli"


### PR DESCRIPTION
Switch to PyPI's Trusted Publishers for more secure upload.

* First, format `pyproject.toml` for easy comparison with other projects.

* Switch backend to hatch with the hatch_vcs plugin to enable publishing to Test PyPI.

* Add new deploy workflow using https://github.com/hynek/build-and-inspect-python-package to confirm we can build packages and inspect as desired. Done for all runs, but not uploaded yet.

* Upload to Test PyPI on every commit on main.

* Upload to real PyPI on GitHub Releases.

* Remove old release job.

TODO:

* [x] Set up Trusted Publisher on https://test.pypi.org/project/cherry_picker/
* [ ] Set up Trusted Publisher on https://pypi.org/project/cherry_picker/
* [ ] Once confirmed working, delete `PYPI_TOKEN` from this repo secrets, it's no longer needed.
* [ ] Once all working, I'll create a release checklist in another PR.