### PR TITLE
Fetch tags so hatch-vcs can set the version number

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       - uses: hynek/build-and-inspect-python-package@v1
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0
 
       - uses: hynek/build-and-inspect-python-package@v1
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,27 +36,3 @@ jobs:
         with:
           flags: ${{ matrix.os }}
           name: ${{ matrix.os }} Python ${{ matrix.python-version }}
-
-  release:
-    needs: test
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.x"
-          cache: pip
-          cache-dependency-path: .github/workflows/main.yml
-      - name: Install tools
-        run: |
-          python -m pip install build twine
-      - name: Release
-        run: |
-          build .
-          twine upload dist/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,10 @@ dev = [
 [project.scripts]
 cherry_picker = "cherry_picker.cherry_picker:cherry_pick_cli"
 
-[tool.hatch]
-version.source = "vcs"
+[tool.hatch.version]
+source = "vcs"
+# Change regex to match tags like "cherry-picker-v2.2.0".
+tag-pattern = '^cherry-picker-(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$'
 
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"


### PR DESCRIPTION
Follow on from https://github.com/python/cherry-picker/pull/94.

Also remove the old release job from `main.yml`.