### PR TITLE
Add release checklist

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -25,5 +25,5 @@
 - [ ] Check installation:
 
 ```bash
-pip3 uninstall -y cherry_picker && pip3 install -U cherry_picker && cherry_picker --version
+python -m pip uninstall -y cherry_picker && python -m pip install -U cherry_picker && cherry_picker --version
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,29 @@
+# Release Checklist
+
+- [ ] check tests pass on [GitHub Actions](https://github.com/python/cherry-picker/actions)
+      [![GitHub Actions status](https://github.com/python/cherry-picker/actions/workflows/main.yml/badge.svg)](https://github.com/python/cherry-picker/actions/workflows/main.yml)
+
+- [ ] Update [changelog](https://github.com/python/cherry-picker#changelog)
+
+- [ ] Go to https://github.com/python/cherry-picker/releases
+
+- [ ] Click "Draft a new release"
+
+- [ ] Click "Choose a tag"
+
+- [ ] Type the next `cherry-picker-vX.Y.Z` version and select "**Create new tag: cherry-picker-vX.Y.Z** on publish"
+
+- [ ] Leave the "Release title" blank (it will be autofilled)
+
+- [ ] Click "Generate release notes" and amend as required
+
+- [ ] Click "Publish release"
+
+- [ ] Check the tagged `GitHub Actions build <https://github.com/python/cherry-picker/actions/workflows/deploy.yml>`
+      has deployed to `PyPI <https://pypi.org/project/cherry_picker/#history>`
+
+- [ ] Check installation:
+
+```bash
+pip3 uninstall -y cherry_picker && pip3 install -U cherry_picker && cherry_picker --version
+```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,19 +5,19 @@
 
 - [ ] Update [changelog](https://github.com/python/cherry-picker#changelog)
 
-- [ ] Go to https://github.com/python/cherry-picker/releases
+- [ ] Go to [Releases page](https://github.com/python/cherry-picker/releases) and
 
-- [ ] Click "Draft a new release"
+  - [ ] Click "Draft a new release"
 
-- [ ] Click "Choose a tag"
+  - [ ] Click "Choose a tag"
 
-- [ ] Type the next `cherry-picker-vX.Y.Z` version and select "**Create new tag: cherry-picker-vX.Y.Z** on publish"
+  - [ ] Type the next `cherry-picker-vX.Y.Z` version and select "**Create new tag: cherry-picker-vX.Y.Z** on publish"
 
-- [ ] Leave the "Release title" blank (it will be autofilled)
+  - [ ] Leave the "Release title" blank (it will be autofilled)
 
-- [ ] Click "Generate release notes" and amend as required
+  - [ ] Click "Generate release notes" and amend as required
 
-- [ ] Click "Publish release"
+  - [ ] Click "Publish release"
 
 - [ ] Check the tagged `GitHub Actions build <https://github.com/python/cherry-picker/actions/workflows/deploy.yml>`
       has deployed to `PyPI <https://pypi.org/project/cherry_picker/#history>`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,8 +19,8 @@
 
   - [ ] Click "Publish release"
 
-- [ ] Check the tagged `GitHub Actions build <https://github.com/python/cherry-picker/actions/workflows/deploy.yml>`
-      has deployed to `PyPI <https://pypi.org/project/cherry_picker/#history>`
+- [ ] Check the tagged [GitHub Actions build] (https://github.com/python/cherry-picker/actions/workflows/deploy.yml)
+      has deployed to [PyPI] (https://pypi.org/project/cherry_picker/#history)
 
 - [ ] Check installation:
 


### PR DESCRIPTION
Checklist for releasing via trusted publishing (https://github.com/python/cherry-picker/pull/94).

---

Note: because the last tags weren't created on `main` (see https://github.com/python/cherry-picker/issues/96), the _first time_ following this, when clicking "Generate release notes", it will pre-fill too much stuff.

So the first time, I suggest to either:

* leave it blank, or
* manually add the new things, or
* generate and remove all except the relevant.
