### PR TITLE
Fix CI: ignore CVE-2023-5752

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -22,4 +22,5 @@ jobs:
       - run: pip install --editable .
       - run: mypy --ignore-missing-imports --install-types --non-interactive .
       - run: shopt -s globstar && pyupgrade --py38-plus **/*.py || true
-      - run: safety check
+      # # Ignore CVE-2023-5752, we're not using that pip or feature
+      - run: safety check --ignore 62044


### PR DESCRIPTION
Not sure what's up with this `safety check`, we upgrade pip at the very start (it's already on latest 23.3.2) and then it complains about a vulnerability in an older version (23.2.1):

```
Run pip install --upgrade pip wheel
Requirement already satisfied: pip in /opt/hostedtoolcache/Python/3.12.1/x64/lib/python3.12/site-packages (23.3.2)
...
-> Vulnerability found in pip version 23.2.1
   Vulnerability ID: 62044
   Affected spec: <23.3
   ADVISORY: Pip 23.3 includes a fix for CVE-2023-5752: When installing
   a package from a Mercurial VCS URL (ie "pip install hg+...") with pip...
   CVE-2023-5752
   For more information, please visit
   https://data.safetycli.com/v/62044/f17
```

https://github.com/python/cherry-picker/actions/runs/7371215995

Anyway, we're not pip installing anything from a Mercurial repo or using this pip version, so let's ignore this warning to fix the CI. 