### PR TITLE
Add GHA ecosystem to `dependabot.yml`.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,19 @@
 version: 2
 updates:
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: monthly
-  open-pull-requests-limit: 10
+  # Maintain dependencies for Python
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: monthly
+    assignees:
+      - "ezio-melotti"
+    open-pull-requests-limit: 10
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly
+    assignees:
+      - "ezio-melotti"
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
-  # Maintain dependencies for Python
-  - package-ecosystem: pip
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: monthly
@@ -9,8 +9,8 @@ updates:
       - "ezio-melotti"
     open-pull-requests-limit: 10
 
-  # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "github-actions"
+  # Maintain dependencies for Python
+  - package-ecosystem: pip
     directory: "/"
     schedule:
       interval: monthly


### PR DESCRIPTION
I noticed that we are a bit behind with some GitHub action versions.  This PR tells dependabot to check and update those too.  While I was at it I reformatted the file and fixed the indentation.