### PR TITLE
Optimize `validate_sha()` with `--max-count=1`

### DIFF
--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -861,7 +861,7 @@ def validate_sha(sha):
 
     raises ValueError if the sha does not reference a commit within the repo
     """
-    cmd = ["git", "log", "-r", sha]
+    cmd = ["git", "log", "--max-count=1", "-r", sha]
     try:
         subprocess.check_output(cmd, stderr=subprocess.STDOUT)
     except subprocess.SubprocessError:


### PR DESCRIPTION
Optimize the `validate_sha()` function with `--max-count=1` to prevent printing the git log of every single commit. See [the "Commit Limiting" section of `git-log`'s man page](https://git-scm.com/docs/git-log#_commit_limiting)

This makes the function near instant.

Currently, running `time git log main > /dev/null` takes about ~1s second for me on the CPython repo, while `time git log --max-count=1 main > /dev/null` (with or without the `-r` flag) only takes about 0.003s.

Additionally, if you've cloned the CPython repo using a [blobless clone (e.g. with `git clone --filter=blob:none https://github.com/python/cpython.git`)](https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/), doing a `git log -r` takes a very long time (almost an hour for me on a slow internet connection!), since the `-r` flag seems to force downloading a blob for every single commit, which makes a blobless clone kind of useless.
