### PR TITLE
Revert #102 after upstream fix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,5 +26,4 @@ jobs:
           # TODO: remove setuptools installation when safety==2.4.0 is released
           python -m pip install --upgrade safety setuptools
           python -m pip install --editable .
-      # Ignore CVE-2023-5752, we're not using that pip or feature
-      - run: safety check --ignore 62044
+      - run: safety check


### PR DESCRIPTION
Due to an upstream issue, we had to skip CVE-2023-5752 to fix CI:
* #102

The issue has now been fixed and released in the `actions/python-versions` repo:
* https://github.com/actions/python-versions/pull/268
* https://github.com/actions/python-versions/pull/254

The `actions/setup-python` repo still doesn't have a release, even though the issue should be fixed:
* https://github.com/actions/setup-python/issues/785

Since there is no `setup-python` release yet, the CI for this PR might fail.  I created it as a reminder to remove the skip and to test whether the issue is actually fixed.