### PR TITLE
Add Python 3.13 to the testing matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "gidgethub",
   "requests",
   # the cffi dep is needed for 3.13, but only a compatible rc is available
-  "cffi==v1.17.0rc1",  # remove this once v1.17.0 is out
+  "cffi>=v1.17.0rc1",  # remove this once v1.17.0 is out
   'tomli>=1.1; python_version < "3.11"',
 ]
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,13 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
 ]
 dynamic = [
   "description",
   "version",
 ]
 dependencies = [
-  "cffi>=v1.17.0rc1", # remove this once v1.17.0 is out (see #127)
+  "cffi>=v1.17.0rc1", # remove once v1.17.0 is out; add 3.13 classifier above (see #127)
   "click>=6",
   "gidgethub",
   "requests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "click>=6",
   "gidgethub",
   "requests",
+  "cffi==v1.17.0rc1",
   'tomli>=1.1; python_version < "3.11"',
 ]
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 dynamic = [
   "description",
@@ -29,7 +30,8 @@ dependencies = [
   "click>=6",
   "gidgethub",
   "requests",
-  "cffi==v1.17.0rc1",
+  # the cffi dep is needed for 3.13, but only a compatible rc is available
+  "cffi==v1.17.0rc1",  # remove this once v1.17.0 is out
   'tomli>=1.1; python_version < "3.11"',
 ]
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "cffi>=v1.17.0rc1",  # remove this once v1.17.0 is out (see #127)
+  "cffi>=v1.17.0rc1", # remove this once v1.17.0 is out (see #127)
   "click>=6",
   "gidgethub",
   "requests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,10 @@ dynamic = [
   "version",
 ]
 dependencies = [
+  "cffi>=v1.17.0rc1",  # remove this once v1.17.0 is out (see #127)
   "click>=6",
   "gidgethub",
   "requests",
-  # the cffi dep is needed for 3.13, but only a compatible rc is available
-  "cffi>=v1.17.0rc1",  # remove this once v1.17.0 is out
   'tomli>=1.1; python_version < "3.11"',
 ]
 [project.optional-dependencies]


### PR DESCRIPTION
This PR adds Python 3.13 to the testing matrix.

It works out of the box on the Ubuntu builders, but it failed on Windows and MacOS because `cffi` failed to build.

There is currently a [`cffi` rc release](https://github.com/python-cffi/cffi/releases/tag/v1.17.0rc1) that is compatible with 3.13.  When I added that all tests passed.
Once a final release is out, the explicit `cffi` dep can be removed.  I added a comment as a reminder.

I would merge this now so that we can start testing on 3.13.
`@dependabot` should create a PR once a new version of `cffi` is out, reminding us to remove it.