### PR TITLE
Remove `setuptools` installation for `safety` 3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,8 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel
-          # TODO: remove setuptools installation when safety==2.4.0 is released
-          python -m pip install --upgrade safety setuptools
+          python -m pip install --upgrade safety
           python -m pip install --editable .
       # Ignore CVE-2023-5752, we're not using that pip or feature
       - run: safety check --ignore 62044


### PR DESCRIPTION
While working on #127 I noticed this TODO:
```# TODO: remove setuptools installation when safety==2.4.0 is released```
We are currently running Safety v3.2.3, so this can be removed.

However, the tests are failing due to an unrelated security issue. See here for more info:
* https://github.com/python/cherry-picker/pull/129
* https://github.com/python/cherry-picker/pull/127#issuecomment-2198419218