### PR TITLE
Ignore Jinja2 CVE warning in `safety` dep

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,5 +26,6 @@ jobs:
           # TODO: remove setuptools installation when safety==2.4.0 is released
           python -m pip install --upgrade safety setuptools
           python -m pip install --editable .
-      # Ignore CVE-2023-5752, we're not using that pip or feature
-      - run: safety check --ignore 62044
+      # Ignore 62044 / CVE-2023-5752, we're not using that pip or feature
+      # Ignore 70612 / CVE-2019-8341, Jinja2 is a safety dep, not ours
+      - run: safety check --ignore 62044 70612

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,4 +28,4 @@ jobs:
           python -m pip install --editable .
       # Ignore 62044 / CVE-2023-5752, we're not using that pip or feature
       # Ignore 70612 / CVE-2019-8341, Jinja2 is a safety dep, not ours
-      - run: safety check --ignore 62044 70612
+      - run: safety check --ignore 62044 --ignore 70612


### PR DESCRIPTION
This PR ignores a Jinja2 CVE warning raised by `safety` and caused by `safety` dep.  `cherry-picker` doesn't use or depend on Jinja2, so it can be safely ignored.

See:
* https://github.com/pyupio/safety/issues/539
* https://github.com/python/cherry-picker/pull/127#issuecomment-2198419218