### PR TITLE
Revert #129 after upstream fix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,5 +25,4 @@ jobs:
           python -m pip install --upgrade pip wheel
           python -m pip install --upgrade safety
           python -m pip install --editable .
-      # Ignore 70612 / CVE-2019-8341, Jinja2 is a safety dep, not ours
-      - run: safety check --ignore 70612
+      - run: safety check


### PR DESCRIPTION
Due to an [upstream issue](https://github.com/pyupio/safety/issues/539), we had to skip CVE-2019-8341 to fix CI:
* https://github.com/python/cherry-picker/pull/129

This draft PR is a reminder to remove the `--ignore` once the issue is fixed upstream and our CI no longer fails without the `--ignore`.