### PR TITLE
Update actions/download-artifact to v4 in deploy.yml.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Download packages built by build-and-inspect-python-package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Packages
           path: dist


### PR DESCRIPTION
There were actually two instances of `actions/download-artifact`, and only one was updated to `@v4`.  This PR updates the other one.