### PR TITLE
Handle whitespace when calculating usernames

### DIFF
--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -196,7 +196,7 @@ class CherryPicker:
     @property
     def username(self):
         cmd = ["git", "config", "--get", f"remote.{self.pr_remote}.url"]
-        result = self.run_cmd(cmd, required_real_result=True).strip("\n")
+        result = self.run_cmd(cmd, required_real_result=True).strip()
         # implicit ssh URIs use : to separate host from user, others just use /
         username = result.replace(":", "/").rstrip("/").split("/")[-2]
         return username

--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -196,7 +196,7 @@ class CherryPicker:
     @property
     def username(self):
         cmd = ["git", "config", "--get", f"remote.{self.pr_remote}.url"]
-        result = self.run_cmd(cmd, required_real_result=True)
+        result = self.run_cmd(cmd, required_real_result=True).strip("\n")
         # implicit ssh URIs use : to separate host from user, others just use /
         username = result.replace(":", "/").rstrip("/").split("/")[-2]
         return username

--- a/cherry_picker/test_cherry_picker.py
+++ b/cherry_picker/test_cherry_picker.py
@@ -351,6 +351,10 @@ def test_get_pr_url(config):
         b"https://github.com/mock_user/cpython.git",
         b"https://github.com/mock_user/cpython",
         b"https://github.com/mock_user/cpython/",
+        # test trailing whitespace
+        b"https://github.com/mock_user/cpython.git\n",
+        b"https://github.com/mock_user/cpython\n",
+        b"https://github.com/mock_user/cpython/\n",
     ],
 )
 def test_username(url, config):


### PR DESCRIPTION
#110 doesn't fully address the issue:

```pycon
>>> import subprocess
>>> subprocess.check_output(["git", "config", "--get", "remote.origin.url"])
b'https://github.com/AA-Turner/cpython\n'
```

A