### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v3.15.0
     hooks:
       - id: pyupgrade
-        args: [--py38-plus]
+        args: [--py39-plus]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 23.12.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{312, 311, 310, 39, 38}
+    py{313, 312, 311, 310, 39}
 isolated_build = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -9,4 +9,9 @@ passenv =
 extras =
     dev
 commands =
-    {envpython} -m pytest --cov cherry_picker --cov-report html --cov-report term --cov-report xml {posargs}
+    {envpython} -m pytest \
+    --cov cherry_picker \
+    --cov-report html \
+    --cov-report term \
+    --cov-report xml \
+    {posargs}


### PR DESCRIPTION
Python 3.8 is end-of-life next month:

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0569/#lifespan
