### PR TITLE
Add Trove classifier for Python 3.13

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,6 +78,11 @@ repos:
     hooks:
       - id: validate-pyproject
 
+  - repo: https://github.com/tox-dev/tox-ini-fmt
+    rev: 1.4.1
+    hooks:
+      - id: tox-ini-fmt
+
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+    rev: v3.17.0
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.12.1
+    rev: 24.8.0
     hooks:
       - id: black
 
@@ -17,13 +17,13 @@ repos:
         args: [--add-import=from __future__ import annotations]
 
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.6
+    rev: 1.7.10
     hooks:
       - id: bandit
         args: ["--skip=B101,B404,B603"]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
+    rev: 7.1.1
     hooks:
       - id: flake8
         additional_dependencies:
@@ -41,7 +41,7 @@ repos:
       - id: python-check-blanket-noqa
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-case-conflict
       - id: check-executables-have-shebangs
@@ -54,7 +54,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.10.1
     hooks:
       - id: mypy
         args:
@@ -69,17 +69,17 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 1.6.0
+    rev: 2.2.4
     hooks:
       - id: pyproject-fmt
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.15
+    rev: v0.19
     hooks:
       - id: validate-pyproject
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
       - id: codespell
         args: [--ignore-words-list=commitish]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,15 +13,27 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:
+      - id: check-added-large-files
       - id: check-case-conflict
       - id: check-executables-have-shebangs
       - id: check-merge-conflict
-      - id: check-json
       - id: check-toml
       - id: check-yaml
       - id: debug-statements
       - id: end-of-file-fixer
+      - id: forbid-submodules
       - id: trailing-whitespace
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.29.2
+    hooks:
+      - id: check-dependabot
+      - id: check-github-workflows
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.1
+    hooks:
+      - id: actionlint
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.10.1
@@ -58,6 +70,11 @@ repos:
     hooks:
       - id: codespell
         args: [--ignore-words-list=commitish]
+
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes
 
 ci:
   autoupdate_schedule: quarterly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,44 +1,14 @@
 repos:
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.17.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.7
     hooks:
-      - id: pyupgrade
-        args: [--py38-plus]
+      - id: ruff
+        args: [--exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.8.0
     hooks:
       - id: black
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: [--add-import=from __future__ import annotations]
-
-  - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.10
-    hooks:
-      - id: bandit
-        args: ["--skip=B101,B404,B603"]
-
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          [
-            flake8-2020,
-            flake8-bugbear,
-            flake8-comprehensions,
-            flake8-implicit-str-concat,
-            flake8-logging,
-          ]
-
-  - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.10.0
-    hooks:
-      - id: python-check-blanket-noqa
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -702,7 +702,7 @@ $ cherry_picker --abort
         return out.startswith("true")
 
 
-CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ requires = [
 [project]
 name = "cherry-picker"
 readme = "README.md"
-maintainers = [{ name = "Python Core Developers", email = "core-workflow@python.org" }]
-authors = [{ name = "Mariatta Wijaya", email = "mariatta@python.org" }]
+maintainers = [ { name = "Python Core Developers", email = "core-workflow@python.org" } ]
+authors = [ { name = "Mariatta Wijaya", email = "mariatta@python.org" } ]
 requires-python = ">=3.8"
 classifiers = [
   "Intended Audience :: Developers",
@@ -26,21 +26,18 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "cffi>=v1.17.0rc1", # remove once v1.17.0 is out; add 3.13 classifier above (see #127)
+  "cffi>=1.17.0rc1",                   # remove once v1.17.0 is out; add 3.13 classifier above (see #127)
   "click>=6",
   "gidgethub",
   "requests",
-  'tomli>=1.1; python_version < "3.11"',
+  "tomli>=1.1; python_version<'3.11'",
 ]
-[project.optional-dependencies]
-dev = [
+optional-dependencies.dev = [
   "pytest",
   "pytest-cov",
 ]
-[project.urls]
-"Homepage" = "https://github.com/python/cherry-picker"
-[project.scripts]
-cherry_picker = "cherry_picker.cherry_picker:cherry_pick_cli"
+urls.Homepage = "https://github.com/python/cherry-picker"
+scripts.cherry_picker = "cherry_picker.cherry_picker:cherry_pick_cli"
 
 [tool.hatch.version]
 source = "vcs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,13 +20,13 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 dynamic = [
   "description",
   "version",
 ]
 dependencies = [
-  "cffi>=1.17.0rc1",                   # remove once v1.17.0 is out; add 3.13 classifier above (see #127)
   "click>=6",
   "gidgethub",
   "requests",
@@ -49,3 +49,6 @@ local_scheme = "no-local-version"
 
 [tool.isort]
 profile = "black"
+
+[tool.pyproject-fmt]
+max_supported_python = "3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,9 +72,6 @@ lint.ignore = [
   "S404", # subprocess module is possibly insecure
   "S603", # subprocess call: check for execution of untrusted input
 ]
-lint.per-file-ignores."cherry_picker/test_*.py" = [
-  "S101", # Asserts allowed in tests
-]
 lint.isort.required-imports = [ "from __future__ import annotations" ]
 
 [tool.pyproject-fmt]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,14 +51,22 @@ local_scheme = "no-local-version"
 fix = true
 
 lint.select = [
-  "C4",  # flake8-comprehensions
-  "ISC", # flake8-implicit-str-concat
-  "LOG", # flake8-logging
-  "PGH", # pygrep-hooks
-  "S",   # flake8-bandit
-  "YTT", # flake8-2020
+  "C4",     # flake8-comprehensions
+  "E",      # pycodestyle errors
+  "F",      # pyflakes errors
+  "I",      # isort
+  "ICN",    # flake8-import-conventions
+  "ISC",    # flake8-implicit-str-concat
+  "LOG",    # flake8-logging
+  "PGH",    # pygrep-hooks
+  "PYI",    # flake8-pyi
+  "RUF022", # unsorted-dunder-all
+  "RUF100", # unused noqa (yesqa)
+  "S",      # flake8-bandit
+  "UP",     # pyupgrade
+  "W",      # pycodestyle warnings
+  "YTT",    # flake8-2020
 ]
-
 lint.ignore = [
   "S101", # Use of assert detected
   "S404", # subprocess module is possibly insecure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ lint.ignore = [
 lint.per-file-ignores."cherry_picker/test_*.py" = [
   "S101", # Asserts allowed in tests
 ]
+lint.isort.required-imports = [ "from __future__ import annotations" ]
 
 [tool.pyproject-fmt]
 max_supported_python = "3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,26 @@ tag-pattern = '^cherry-picker-(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"
 
-[tool.isort]
-profile = "black"
+[tool.ruff]
+fix = true
+
+lint.select = [
+  "C4",  # flake8-comprehensions
+  "ISC", # flake8-implicit-str-concat
+  "LOG", # flake8-logging
+  "PGH", # pygrep-hooks
+  "S",   # flake8-bandit
+  "YTT", # flake8-2020
+]
+
+lint.ignore = [
+  "S101", # Use of assert detected
+  "S404", # subprocess module is possibly insecure
+  "S603", # subprocess call: check for execution of untrusted input
+]
+lint.per-file-ignores."cherry_picker/test_*.py" = [
+  "S101", # Asserts allowed in tests
+]
 
 [tool.pyproject-fmt]
 max_supported_python = "3.13"

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ requires =
     tox>=4.2
 env_list =
     py{313, 312, 311, 310, 39}
-isolated_build = true
 
 [testenv]
 extras =
@@ -12,8 +11,8 @@ pass_env =
     FORCE_COLOR
 commands =
     {envpython} -m pytest \
-    --cov cherry_picker \
-    --cov-report html \
-    --cov-report term \
-    --cov-report xml \
-    {posargs}
+      --cov cherry_picker \
+      --cov-report html \
+      --cov-report term \
+      --cov-report xml \
+      {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
-envlist =
+requires =
+    tox>=4.2
+env_list =
     py{312, 311, 310, 39, 38}
-isolated_build = true
 
 [testenv]
-passenv =
-    FORCE_COLOR
 extras =
     dev
+pass_env =
+    FORCE_COLOR
 commands =
     {envpython} -m pytest --cov cherry_picker --cov-report html --cov-report term --cov-report xml {posargs}


### PR DESCRIPTION
```toml
dependencies = [
  "cffi>=v1.17.0rc1", # remove once v1.17.0 is out; add 3.13 classifier above (see #127)
```

cffi 1.17.1 is now out: https://pypi.org/project/cffi/ 

Also replace Flake8 with Ruff, and add some extra linting.