### PR TITLE
PyPI metatada: re-add description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires = [
 
 [project]
 name = "cherry-picker"
+description = "Backport CPython changes from main to maintenance branches"
 readme = "README.md"
 maintainers = [ { name = "Python Core Developers", email = "core-workflow@python.org" } ]
 authors = [ { name = "Mariatta Wijaya", email = "mariatta@python.org" } ]
@@ -21,10 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-dynamic = [
-  "description",
-  "version",
-]
+dynamic = [ "version" ]
 dependencies = [
   "click>=6",
   "gidgethub",
@@ -48,7 +46,6 @@ local_scheme = "no-local-version"
 
 [tool.ruff]
 fix = true
-
 lint.select = [
   "C4",     # flake8-comprehensions
   "E",      # pycodestyle errors


### PR DESCRIPTION
2.2.0 has a summary:
https://inspector.pypi.io/project/cherry-picker/2.2.0/packages/39/e1/d9ea0ed117ea8a16c5c0246c778204d1a5547063e8531d3b8360189ed220/cherry_picker-2.2.0.tar.gz/cherry_picker-2.2.0/PKG-INFO#line.4

2.3.0 does not:
https://inspector.pypi.io/project/cherry-picker/2.3.0/packages/f0/ed/8da91acfb637f596f8004efffc68db1fabbe57823ff7fc1f2e04e0bb0036/cherry_picker-2.3.0.tar.gz/cherry_picker-2.3.0/PKG-INFO

Also visible in the PyPI HTML, where 2.3.0 has ` <meta name="description" content="None">`

Flit has dynamic description, but we moved to Hatchling which does not. That's okay, it's not like it will change much, unlike the version.

Let's re-add it.
