### PR TITLE
Generate `__version__` at build to avoid slow `importlib.metadata` import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -399,3 +399,6 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.gitignore.io/api/git,linux,pydev,python,windows,pycharm+all,jupyternotebook,vim,webstorm,emacs
+
+# hatch-vcs
+cherry_picker/_version.py

--- a/cherry_picker/__init__.py
+++ b/cherry_picker/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-import importlib.metadata
+from ._version import __version__
 
-__version__ = importlib.metadata.version(__name__)
+__all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ source = "vcs"
 # Change regex to match tags like "cherry-picker-v2.2.0".
 tag-pattern = '^cherry-picker-(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$'
 
+[tool.hatch.build.hooks.vcs]
+version-file = "cherry_picker/_version.py"
+
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"
 


### PR DESCRIPTION
Like https://github.com/python/blurb/pull/30.

`importlib.metadata` is quite a heavy library to import, and can make CLI use less snappy.

It's only used for fetching the version, and we can pre-generate it as part of our regular build instead.

The call itself is also slow, for example 15s:  https://github.com/python/blurb/pull/30#pullrequestreview-2362241316.

# Before

```
python -X importtime -c "import cherry_picker" 2> import.log && tuna import.log
```

<img width="1582" alt="image" src="https://github.com/user-attachments/assets/d8105d6d-bcc7-418a-a233-dfca597b907c">

<img width="1582" alt="image" src="https://github.com/user-attachments/assets/2d80843e-5b41-4e8b-aaa3-c1d6a57491b9">

# After

<img width="1582" alt="image" src="https://github.com/user-attachments/assets/ae34f054-a0a8-4d23-9de8-2451008837f2">

<img width="1582" alt="image" src="https://github.com/user-attachments/assets/1d916ca5-4329-4aa5-b5f1-3aecafc85851">
