### PR TITLE
Remove outdated README info

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,13 @@ Write tests using [pytest](https://docs.pytest.org/).
 
 ## Setup info
 
-Requires Python 3.8+.
-
 ```console
 $ python3 -m venv venv
 $ source venv/bin/activate
 (venv) $ python -m pip install cherry_picker
 ```
 
-The cherry picking script assumes that if an `upstream` remote is defined, then
+The cherry-picking script assumes that if an `upstream` remote is defined, then
 it should be used as the source of upstream changes and as the base for
 cherry-pick branches. Otherwise, `origin` is used for that purpose.
 You can override this behavior with the `--upstream-remote` option


### PR DESCRIPTION
Remove "Requires Python 3.8+", support for 3.8 was dropped in https://github.com/python/cherry-picker/pull/137.

These bits of texts are often forgotten, we can check `pyproject.toml` or see the README badges for the actual minimum required version:

![image](https://github.com/user-attachments/assets/569d0c63-4ad0-40ad-a77e-f93736a35353)
