### PR TITLE
Update CI config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: hynek/build-and-inspect-python-package@v2
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,6 @@ jobs:
       - name: Publish to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          attestations: true
           repository-url: https://test.pypi.org/legacy/
 
   # Publish to PyPI on GitHub Releases.
@@ -75,5 +74,3 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          attestations: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,9 +19,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-          cache: pip
-          cache-dependency-path: .github/workflows/lint.yml
-      - uses: pre-commit/action@v3.0.1
+      - uses: tox-dev/action-pre-commit-uv@v1
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,10 +20,5 @@ jobs:
         with:
           python-version: "3.x"
       - uses: tox-dev/action-pre-commit-uv@v1
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip wheel
-          python -m pip install --upgrade safety
-          python -m pip install --editable .
       # Ignore 70612 / CVE-2019-8341, Jinja2 is a safety dep, not ours
-      - run: safety check --ignore 70612
+      - run: uvx safety check --ignore 70612

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
           # fetch all branches and tags
           # ref actions/checkout#448
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,15 +30,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-          cache: pip
-          cache-dependency-path: pyproject.toml
 
-      - name: Install tox
-        run: |
-          python -m pip install tox
+      - name: Install uv
+        uses: hynek/setup-cached-uv@v2
 
       - name: Run tests
-        run: tox -e py
+        run: uvx --with tox-uv tox -e py
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.8
+    rev: v0.7.4
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.8.0
+    rev: 24.10.0
     hooks:
       - id: black
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -25,20 +25,21 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.29.2
+    rev: 0.29.4
     hooks:
       - id: check-dependabot
       - id: check-github-workflows
 
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.2
+    rev: v1.7.4
     hooks:
       - id: actionlint
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
+    rev: v1.13.0
     hooks:
       - id: mypy
+        additional_dependencies: [types-requests]
         args:
           [
             --ignore-missing-imports,
@@ -51,12 +52,12 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 2.2.4
+    rev: v2.5.0
     hooks:
       - id: pyproject-fmt
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.20.2
+    rev: v0.23
     hooks:
       - id: validate-pyproject
 


### PR DESCRIPTION
* Since https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.11.0, attestations are on by default
* Fix https://github.com/woodruffw/zizmor findings
* Lint with faster tox-dev/action-pre-commit-uv instead of pre-commit/action
* Test with faster tox-uv instead of tox
* Explicitly install types-requests stub for mypy:
  * Hopefully this will fix https://results.pre-commit.ci/run/github/189480743/1731754171.XKt0Ak99QxiRvNKM2Ug2DA -- mypy quietly installs `types-requests` if `requests` is used, but let's try installing explicitly. Also fixes when using `pre-commit-uv` that doesn't have pip.
* Install and run safety via uv
