### PR TITLE
Better error message when cherry-picker repo state is invalid

### DIFF
--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -812,7 +812,14 @@ def cherry_pick_cli(
             config=config,
             chosen_config_path=chosen_config_path,
         )
-    except InvalidRepoException:
+    except InvalidRepoException as e:
+        if "--remove-section cherry-picker" in str(e):
+            click.echo(
+                "The cherry-picker state in the Git config is invalid. "
+                "You might need to run `git config --local "
+                "--remove-section cherry-picker`,"
+            )
+            sys.exit(-1)
         click.echo(f"You're not inside a {config['repo']} repo right now! \U0001F645")
         sys.exit(-1)
     except ValueError as exc:


### PR DESCRIPTION
When I played with cherry-picker as we introduced it in Airflow, I manage to set the repo to the state where I always got the message "You're not inside a airflow repo right now!"

After short debugging it turned out that it is because I manage to Ctrl-C and mix `git cherry-pick --abort` with `cherry_picker` commands - when I learned how to use it, I did not know that I had to only use `cherry-picker --continue` command rather than git commands.

This might happen to others, so I think we should have a better way to handle this case.

When this happens you get this exception:

```pytb
Traceback (most recent call last):
  File "/Users/jarek/IdeaProjects/cherry-picker/cherry_picker/cherry_picker.py", line 666, in check_repo
    self.get_state_and_verify()
  File "/Users/jarek/IdeaProjects/cherry-picker/cherry_picker/cherry_picker.py", line 684, in get_state_and_verify
    raise ValueError(
ValueError: Run state cherry-picker.state=BACKPORT_LOOP_START in Git config is not known.
Perhaps it has been set by a newer version of cherry-picker. Try upgrading.
Valid states are: BACKPORT_PAUSED, UNSET. If this looks suspicious, raise an issue at https://github.com/python/cherry-picker/issues/new.
As the last resort you can reset the runtime state stored in Git config using the following command: `git config --local --remove-section cherry-picker`

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/jarek/.local/bin/cherry_picker", line 8, in <module>
    sys.exit(cherry_pick_cli())
             ^^^^^^^^^^^^^^^^^
  File "/Users/jarek/.local/share/uv/tools/cherry-picker/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jarek/.local/share/uv/tools/cherry-picker/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/jarek/.local/share/uv/tools/cherry-picker/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jarek/.local/share/uv/tools/cherry-picker/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jarek/.local/share/uv/tools/cherry-picker/lib/python3.12/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jarek/IdeaProjects/cherry-picker/cherry_picker/cherry_picker.py", line 804, in cherry_pick_cli
    cherry_picker = CherryPicker(
                    ^^^^^^^^^^^^^
  File "/Users/jarek/IdeaProjects/cherry-picker/cherry_picker/cherry_picker.py", line 123, in __init__
    self.check_repo()  # may raise InvalidRepoException
    ^^^^^^^^^^^^^^^^^
  File "/Users/jarek/IdeaProjects/cherry-picker/cherry_picker/cherry_picker.py", line 668, in check_repo
    raise InvalidRepoException(ve.args[0])
cherry_picker.cherry_picker.InvalidRepoException: Run state cherry-picker.state=BACKPORT_LOOP_START in Git config is not known.
Perhaps it has been set by a newer version of cherry-picker. Try upgrading.
Valid states are: BACKPORT_PAUSED, UNSET. If this looks suspicious, raise an issue at https://github.com/python/cherry-picker/issues/new.
As the last resort you can reset the runtime state stored in Git config using the following command: `git config --local --remove-section cherry-picker`
```

So this PR checks for presence of that message in the exception and it will provide better explanation, and guidance in this case.

Fixes: #99