### PR TITLE
Fix mypy pre-commit settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,13 +42,12 @@ repos:
         args:
           [
             --ignore-missing-imports,
-            --install-types,
-            --non-interactive,
             --pretty,
             --show-error-codes,
             .,
           ]
         pass_filenames: false
+        additional_dependencies: ["types-requests"]
 
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: 2.2.4


### PR DESCRIPTION
When proposing #147 I noticed that mypy failed with missing `types-request` - and while the mypy configuration had the `--install-types`, it did not work automatically for requests.

The error was:

```
cherry_picker/cherry_picker.py:15: error: Library stubs not installed for
"requests"  [import-untyped]
    import requests
    ^
cherry_picker/cherry_picker.py:15: note: Hint: "python3 -m pip install types-requests"
cherry_picker/cherry_picker.py:15: note: (or run "mypy --install-types" to install all missing stub packages)
cherry_picker/cherry_picker.py:15: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
```

I looked a bit closer and noticed the advice from
https://github.com/pre-commit/mirrors-mypy

> Note that using the --install-types is problematic. Mutating the
pre-commit environment at runtime breaks cache and will break parallel builds.

This PR fixes the problem by removing `--install-types` and installing types-requests explicitly as additional-dependencies.

starting