### PR TITLE
Ignore uv.lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -402,3 +402,6 @@ $RECYCLE.BIN/
 
 # hatch-vcs
 cherry_picker/_version.py
+
+# Ignore uv.lock
+uv.lock


### PR DESCRIPTION
When somoene uses `uv` to manage their venv, uv.lock is generated automatically when `uv sync` is run. This PR removes it, so that it is not committed accidentally (happened in #147)