### PR TITLE
Add draft config option to Create Pull Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ check_sha = "f382b5ffc445e45a110734f5396728da7914aeb6"
 fix_commit_msg = false
 default_branch = "devel"
 require_version_in_branch_name = false
+draft_pr = false
 ```
 
 Available config options:
@@ -169,6 +170,9 @@ default_branch                  Project's default branch name,
 require_version_in_branch_name  Allow backporting to branches whose names don't contain
                                 something that resembles a version number
                                 (i.e. at least two dot-separated numbers).
+
+draft_pr                        Create PR as draft
+                                (false by default)
 ```
 
 To customize the tool for used by other project:

--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -33,6 +33,7 @@ DEFAULT_CONFIG = collections.ChainMap(
         "fix_commit_msg": True,
         "default_branch": "main",
         "require_version_in_branch_name": True,
+        "draft_pr": False,
     }
 )
 
@@ -454,6 +455,7 @@ $ cherry_picker --abort
             "head": f"{self.username}:{head_branch}",
             "base": base_branch,
             "maintainer_can_modify": True,
+            "draft": self.config["draft_pr"],
         }
         url = CREATE_PR_URL_TEMPLATE.format(config=self.config)
         response = requests.post(url, headers=request_headers, json=data, timeout=10)

--- a/cherry_picker/test_cherry_picker.py
+++ b/cherry_picker/test_cherry_picker.py
@@ -7,6 +7,7 @@ import subprocess
 import warnings
 from collections import ChainMap
 from unittest import mock
+from unittest.mock import MagicMock
 
 import click
 import pytest
@@ -491,6 +492,7 @@ def test_load_full_config(tmp_git_repo_dir, git_add, git_commit):
             "fix_commit_msg": True,
             "default_branch": "devel",
             "require_version_in_branch_name": True,
+            "draft_pr": False,
         },
     )
 
@@ -515,6 +517,7 @@ def test_load_partial_config(tmp_git_repo_dir, git_add, git_commit):
             "fix_commit_msg": True,
             "default_branch": "main",
             "require_version_in_branch_name": True,
+            "draft_pr": False,
         },
     )
 
@@ -544,6 +547,7 @@ def test_load_config_no_head_sha(tmp_git_repo_dir, git_add, git_commit):
             "fix_commit_msg": True,
             "default_branch": "devel",
             "require_version_in_branch_name": True,
+            "draft_pr": False,
         },
     )
 
@@ -1332,3 +1336,51 @@ def test_abort_cherry_pick_success(
 
 def test_cli_invoked():
     subprocess.check_call("cherry_picker --help".split())
+
+
+@pytest.mark.parametrize("draft_pr", (True, False))
+@mock.patch("requests.post")
+@mock.patch("gidgethub.sansio.create_headers")
+@mock.patch.object(CherryPicker, "username", new_callable=mock.PropertyMock)
+def test_create_gh_pr_draft_states(
+    mock_username, mock_create_headers, mock_post, monkeypatch, draft_pr, config
+):
+    config["draft_pr"] = draft_pr
+    mock_username.return_value = "username"
+    monkeypatch.setenv("GH_AUTH", "True")
+    with mock.patch("cherry_picker.cherry_picker.validate_sha", return_value=True):
+        cherry_picker = CherryPicker(
+            "origin", "xxx", [], prefix_commit=True, config=config
+        )
+    mock_create_headers.return_value = {"Authorization": "token gh-token"}
+
+    mock_response = MagicMock()
+    mock_response.status_code = 201
+    mock_response.json.return_value = {
+        "html_url": "https://github.com/octocat/Hello-World/pull/1347",
+        "number": 1347,
+    }
+    mock_post.return_value = mock_response
+
+    base_branch = "main"
+    head_branch = "feature-branch"
+    commit_message = "Commit message"
+    gh_auth = "gh_auth"
+
+    cherry_picker.create_gh_pr(
+        base_branch, head_branch, commit_message=commit_message, gh_auth=gh_auth
+    )
+
+    mock_post.assert_called_once_with(
+        "https://api.github.com/repos/python/cpython/pulls",
+        headers={"Authorization": "token gh-token"},
+        json={
+            "title": "Commit message",
+            "body": "",
+            "head": "username:feature-branch",
+            "base": "main",
+            "maintainer_can_modify": True,
+            "draft": draft_pr,
+        },
+        timeout=10,
+    )


### PR DESCRIPTION
Adding draft parameter option to create pull request.
https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#create-a-pull-request

At Airflow, we effectively use the cherry-picker tool to backport changes, which has been highly beneficial in saving maintainers' time.

Currently, we have configured cherry-picker in our workflows, utilizing the GITHUB_TOKEN to create backport PRs. However, our workflows are not triggered on these backported PRs. This limitation occurs because GitHub prevents recursive workflows when using the default token.

https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow .

To address this, we would like to create backport PRs in draft state. maintainer can then change them to the "Ready for Review" state, which will subsequently trigger the workflows.

Thank you @potiuk for the suggestion this.