### PR TITLE
Acknowledge network issues on GitHub

### DIFF
--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -568,7 +568,7 @@ $ cherry_picker --abort
                         )
                     except GitHubException:
                         click.echo(self.get_exit_message(maint_branch))
-                        self.set_paused_state()                        
+                        self.set_paused_state()
                         raise
                     if not self.is_mirror():
                         self.cleanup_branch(cherry_pick_branch)

--- a/cherry_picker/test_cherry_picker.py
+++ b/cherry_picker/test_cherry_picker.py
@@ -1386,5 +1386,5 @@ def test_create_gh_pr_draft_states(
             "maintainer_can_modify": True,
             "draft": draft_pr,
         },
-        timeout=10,
+        timeout=30,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "click>=6",
   "gidgethub",
   "requests",
+  "stamina",
   "tomli>=1.1; python_version<'3.11'",
 ]
 optional-dependencies.dev = [


### PR DESCRIPTION
On miss-islington we quite regularly get failures due to sporadic GitHub network issues. This change introduces retries for the specific case of GH PR creation and sets the repository in a paused state afterwards to allow the user to wait and `--continue` or `--abort`.

Previously, the repository was left in a PR_CREATING state, which was not expected by cherry-picker on a re-run.