### PR TITLE
Check commit count against `upstream`

### DIFF
--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -636,7 +636,7 @@ $ cherry_picker --abort
             ]
             self.commit_sha1 = get_full_sha_from_short(short_sha)
 
-            commits = get_commits_from_backport_branch(f"{self.upstream_remote}/{base}")
+            commits = get_commits_from_backport_branch(f"{self.upstream}/{base}")
             if len(commits) == 1:
                 commit_message = self.amend_commit_message(cherry_pick_branch)
             else:

--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -636,7 +636,7 @@ $ cherry_picker --abort
             ]
             self.commit_sha1 = get_full_sha_from_short(short_sha)
 
-            commits = get_commits_from_backport_branch(base)
+            commits = get_commits_from_backport_branch(f"{self.upstream_remote}/{base}")
             if len(commits) == 1:
                 commit_message = self.amend_commit_message(cherry_pick_branch)
             else:


### PR DESCRIPTION
Previously, the `git log` command would run against an unresolved branch reference, which might point to the wrong thing locally. This patch makes it more predictable by specifying the exact remote branch.

Fixes #124
Fixes #155