### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,10 @@ license = "Apache-2.0"
 license-files = [ "LICENSE" ]
 maintainers = [ { name = "Python Core Developers", email = "core-workflow@python.org" } ]
 authors = [ { name = "Mariatta Wijaya", email = "mariatta@python.org" } ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 requires =
     tox>=4.2
 env_list =
-    py{313, 312, 311, 310, 39}
+    py{313, 312, 311, 310}
 
 [testenv]
 extras =


### PR DESCRIPTION
It's almost EOL:

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0596/
