### PR TITLE
Improve error output when a command fails

### DIFF
--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -233,7 +233,11 @@ class CherryPicker:
         if not required_real_result and self.dry_run:
             click.echo(f"  dry-run: {' '.join(cmd)}")
             return
-        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+        try:
+            output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as exc:
+            click.echo(exc.output.decode("utf-8"))
+            raise
         return output.decode("utf-8")
 
     def checkout_branch(self, branch_name, *, create_branch=False):


### PR DESCRIPTION
Fixes https://github.com/python/cherry-picker/issues/100.

Sometimes cherry-picker fails and it really doesn't tell you why:

<details>
<summary>Uninformative error</summary>


```pytb
❯ cherry_picker --continue
🐍 🍒 ⛏
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.14/bin/cherry_picker", line 10, in <module>
    sys.exit(cherry_pick_cli())
             ~~~~~~~~~~~~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/click/core.py", line 1485, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/click/core.py", line 1406, in main
    rv = self.invoke(ctx)
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/click/core.py", line 1269, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/click/core.py", line 824, in invoke
    return callback(*args, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/click/decorators.py", line 34, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/cherry_picker/cherry_picker.py", line 855, in cherry_pick_cli
    cherry_picker.continue_cherry_pick()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/cherry_picker/cherry_picker.py", line 657, in continue_cherry_pick
    self.run_cmd(cmd)
    ~~~~~~~~~~~~^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/cherry_picker/cherry_picker.py", line 236, in run_cmd
    output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/subprocess.py", line 472, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
               **kwargs).stdout
               ^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/subprocess.py", line 577, in run
    raise CalledProcessError(retcode, process.args,
                             output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['git', 'commit', '-a', '-m', '[3.14] gh-146488: hash-pin all action references\n(cherry picked from commit a504c0a590b9379688e4718225efb361b94cc4a1)\n\nCo-authored-by: William Woodruff <william@yossarian.net>\nSigned-off-by: William Woodruff <william@yossarian.net>', '--allow-empty']' returned non-zero exit status 1.
```

</details>

I have no idea what is wrong from the above. I reset, resolved my conflict and tried again. Same error.

But sometimes this is caused by `git commit` failing. It helps to show what actually went wrong:

<details>
<summary>Details</summary>

```pytb
❯ cherry_picker --continue
🐍 🍒 ⛏
Run Ruff (lint) on Apple/............................(no files to check)Skipped
Run Ruff (lint) on Doc/..............................(no files to check)Skipped
Run Ruff (lint) on Lib/test/.........................(no files to check)Skipped
Run Ruff (lint) on Tools/build/......................(no files to check)Skipped
Run Ruff (lint) on Tools/i18n/.......................(no files to check)Skipped
Run Ruff (lint) on Argument Clinic...................(no files to check)Skipped
Run Ruff (lint) on Tools/peg_generator/..............(no files to check)Skipped
Run Ruff (lint) on Tools/wasm/.......................(no files to check)Skipped
Run Ruff (format) on Apple/..........................(no files to check)Skipped
Run Ruff (format) on Doc/............................(no files to check)Skipped
Run Ruff (format) on Tools/build/check_warnings.py...(no files to check)Skipped
Run Ruff (format) on Tools/wasm/.....................(no files to check)Skipped
Run Black on Tools/jit/..............................(no files to check)Skipped
Tabs remover.........................................(no files to check)Skipped
check for case conflicts.................................................Passed
check for merge conflicts................................................Passed
check toml...........................................(no files to check)Skipped
check yaml...............................................................Passed
fix end of files.........................................................Passed
fix end of files.....................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
trim trailing whitespace.............................(no files to check)Skipped
Validate Dependabot Config (v2)......................(no files to check)Skipped
Validate GitHub Workflows................................................Passed
Validate ReadTheDocs Config..........................(no files to check)Skipped
Lint GitHub Actions workflow files.......................................Passed
zizmor...................................................................Failed
- hook id: zizmor
- exit code: 14

  error[unpinned-uses]: unpinned action reference
    --> .github/workflows/reusable-cifuzz.yml:24:15
     |
  24 |         uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
     |
     = note: audit confidence → High
     = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses

  error[unpinned-uses]: unpinned action reference
    --> .github/workflows/reusable-cifuzz.yml:29:15
     |
  29 |         uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
     |
     = note: audit confidence → High
     = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses

  117 findings (4 ignored, 111 suppressed): 0 informational, 0 low, 0 medium, 2 high
  🌈 zizmor v1.22.0
   INFO audit: zizmor: 🌈 completed .github/workflows/add-issue-header.yml
   INFO audit: zizmor: 🌈 completed .github/workflows/build.yml
   INFO audit: zizmor: 🌈 completed .github/workflows/documentation-links.yml
   WARN audit: zizmor: one or more inputs contains YAML anchors; you may encounter crashes or unpredictable behavior
   WARN audit: zizmor: for more information, see: https://docs.zizmor.sh/usage/#yaml-anchors
   INFO audit: zizmor: 🌈 completed .github/workflows/jit.yml
   INFO audit: zizmor: 🌈 completed .github/workflows/lint.yml
   INFO audit: zizmor: 🌈 completed .github/workflows/mypy.yml
   INFO audit: zizmor: 🌈 completed .github/workflows/new-bugs-announce-notifier.yml
   INFO audit: zizmor: 🌈 completed .github/workflows/project-updater.yml
   INFO audit: zizmor: 🌈 completed .github/workflows/require-pr-label.yml
   INFO audit: zizmor: 🌈 completed .github/workflows/reusable-cifuzz.yml
   INFO audit: zizmor: 🌈 completed .github/workflows/reusable-context.yml
   INFO audit: zizmor: 🌈 completed .github/workflows/reusable-docs.yml
   INFO audit: zizmor: 🌈 completed .github/workflows/reusable-emscripten.yml
   INFO audit: zizmor: 🌈 completed .github/workflows/reusable-macos.yml
   INFO audit: zizmor: 🌈 completed .github/workflows/reusable-san.yml
   INFO audit: zizmor: 🌈 completed .github/workflows/reusable-ubuntu.yml
   INFO audit: zizmor: 🌈 completed .github/workflows/reusable-wasi.yml
   INFO audit: zizmor: 🌈 completed .github/workflows/reusable-windows-msi.yml
   INFO audit: zizmor: 🌈 completed .github/workflows/reusable-windows.yml
   INFO audit: zizmor: 🌈 completed .github/workflows/stale.yml
   INFO audit: zizmor: 🌈 completed .github/workflows/tail-call.yml
   INFO audit: zizmor: 🌈 completed .github/workflows/verify-ensurepip-wheels.yml
   INFO audit: zizmor: 🌈 completed .github/workflows/verify-expat.yml
Sphinx Lint..........................................(no files to check)Skipped
Check C API news entries.............................(no files to check)Skipped
Check Core and Builtins news entries.................(no files to check)Skipped
Check hooks apply....................................(no files to check)Skipped
Check useless excludes...............................(no files to check)Skipped

Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.14/bin/cherry_picker", line 10, in <module>
    sys.exit(cherry_pick_cli())
             ~~~~~~~~~~~~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/click/core.py", line 1485, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/click/core.py", line 1406, in main
    rv = self.invoke(ctx)
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/click/core.py", line 1269, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/click/core.py", line 824, in invoke
    return callback(*args, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/click/decorators.py", line 34, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/hugo/github/cherry-picker/cherry_picker/cherry_picker.py", line 859, in cherry_pick_cli
    cherry_picker.continue_cherry_pick()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/hugo/github/cherry-picker/cherry_picker/cherry_picker.py", line 661, in continue_cherry_pick
    self.run_cmd(cmd)
    ~~~~~~~~~~~~^^^^^
  File "/Users/hugo/github/cherry-picker/cherry_picker/cherry_picker.py", line 237, in run_cmd
    output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/subprocess.py", line 472, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
               **kwargs).stdout
               ^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/subprocess.py", line 577, in run
    raise CalledProcessError(retcode, process.args,
                             output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['git', 'commit', '-a', '-m', '[3.14] gh-146488: hash-pin all action references\n(cherry picked from commit a504c0a590b9379688e4718225efb361b94cc4a1)\n\nCo-authored-by: William Woodruff <william@yossarian.net>\nSigned-off-by: William Woodruff <william@yossarian.net>', '--allow-empty']' returned non-zero exit status 1.
```

</details>

Aha! In this case, I can see pre-commit found an action that wasn't pinned, and the whole point of my backport is to pin them! I now know what to do!