### PR TITLE
Remove redundant `.flake8` file

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-extend-ignore = C408,E203,F841,W503
-max-complexity = 12
-max-line-length = 88


### PR DESCRIPTION
We no longer use this file since moving to Ruff in https://github.com/python/cherry-picker/pull/134.