### PR TITLE
Replace `click.echo` with `print`

### DIFF
--- a/cherry_picker/cherry_picker.py
+++ b/cherry_picker/cherry_picker.py
@@ -241,7 +241,7 @@ class CherryPicker:
         try:
             output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as exc:
-            click.echo(exc.output.decode("utf-8"))
+            print(exc.output.decode("utf-8"))
             raise
         return output.decode("utf-8")
 


### PR DESCRIPTION
Oops, missed one from https://github.com/python/cherry-picker/pull/186.

Edit: or it actually crossed in-flight from https://github.com/python/cherry-picker/pull/176 :)