### PR TITLE
Update changelog for 2.7.0

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,5 +1,5 @@
 changelog:
   exclude:
     authors:
-      - dependabot
-      - pre-commit-ci
+      - dependabot[bot]
+      - pre-commit-ci[bot]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.7.0
+
+* Improve error output when a command fails by @hugovk in https://github.com/python/cherry-picker/pull/176
+* Replace Click dependency with argparse by @hugovk in https://github.com/python/cherry-picker/pull/186
+* Add support for Python 3.15 by @hugovk in https://github.com/python/cherry-picker/pull/171
+* Drop support for Python 3.9 by @hugovk in https://github.com/python/cherry-picker/pull/164
+
 ## 2.6.0
 
 * Check commit count against `upstream` by @webknjaz in https://github.com/python/cherry-picker/pull/156

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,9 +9,9 @@
 
   - [ ] Click "Draft a new release"
 
-  - [ ] Click "Choose a tag"
+  - [ ] Click "Select tag"
 
-  - [ ] Type the next `cherry-picker-vX.Y.Z` version and select "**Create new tag: cherry-picker-vX.Y.Z** on publish"
+  - [ ] Type the next `cherry-picker-vX.Y.Z` version, click "Create new tag" then "Create"
 
   - [ ] Leave the "Release title" blank (it will be autofilled)
 


### PR DESCRIPTION
Let's make a new release.

This PR updates the changelog, and also:

* Update release checklist -- no process change, just some UI button text
* Update bot PR authors to ignore when auto-generating release notes, they now have `[bot]` in their names